### PR TITLE
Fix http request queue growing without bounds if the requests aren't being processed fast enough.

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/http/HttpCardSender.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/panel/http/HttpCardSender.java
@@ -4,17 +4,21 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
-import shedar.mods.ic2.nuclearcontrol.IC2NuclearControl;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
+
 import argo.jdom.JsonNodeBuilder;
 import argo.jdom.JsonNodeBuilders;
 import argo.jdom.JsonObjectNodeBuilder;
+import shedar.mods.ic2.nuclearcontrol.IC2NuclearControl;
 
 public class HttpCardSender {
 	private static final String ID_URL_TEMPLATE = "http://sensors.modstats.org/api/v1/register?p=";
@@ -22,9 +26,10 @@ public class HttpCardSender {
 	public static HttpCardSender instance = new HttpCardSender();
 
 	@SuppressWarnings("rawtypes")
-	private ConcurrentHashMap<Long, JsonNodeBuilder> unsent = new ConcurrentHashMap<Long, JsonNodeBuilder>();
+	private final ConcurrentHashMap<Long, JsonNodeBuilder> unsent = new ConcurrentHashMap<Long, JsonNodeBuilder>();
 	public ConcurrentLinkedQueue<Long> availableIds = new ConcurrentLinkedQueue<Long>();
-	private ExecutorService executor = Executors.newFixedThreadPool(2);
+	// single thread executor service with a maximum queue size of 64 elements
+	private final ExecutorService executor = new ThreadPoolExecutor(1, 1, 0, TimeUnit.SECONDS, new ArrayBlockingQueue<Runnable>(64));
 
 	private HttpCardSender() {}
 
@@ -33,6 +38,9 @@ public class HttpCardSender {
 			executor.submit(new Request(new URL(ID_URL_TEMPLATE + IC2NuclearControl.instance.httpSensorKey), null));
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
+		} catch (RejectedExecutionException e) {
+			// the server isn't processing requests fast enough, drop the request
+			// TODO: reschedule? fallback?
 		}
 	}
 
@@ -41,6 +49,9 @@ public class HttpCardSender {
 			executor.submit(new Request(new URL(DATA_URL_TEMPLATE), unsent));
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
+		} catch (RejectedExecutionException e) {
+			// the server isn't processing requests fast enough, drop the request
+			// TODO: reschedule? fallback?
 		}
 	}
 


### PR DESCRIPTION
The executor service queue grows to millions of elements fairly quickly, this commit limits it to 64 elements and rejects any excess.

Cutting the request spam down is still needed, I don't quite see why it's using an external server anyway. Handling failed/rejected requests also needs work.

Note this is untested.