### PR TITLE
IC2 Classic Update

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/IC2NuclearControl.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/IC2NuclearControl.java
@@ -1,9 +1,47 @@
 package shedar.mods.ic2.nuclearcontrol;
 
-import cpw.mods.fml.common.Mod;
+import java.io.File;
+import java.util.List;
 
+import net.minecraft.item.Item;
+import net.minecraftforge.common.MinecraftForge;
+
+import org.apache.logging.log4j.Logger;
+
+import shedar.mods.ic2.nuclearcontrol.blocks.BlockNuclearControlLight;
+import shedar.mods.ic2.nuclearcontrol.blocks.BlockNuclearControlMain;
+import shedar.mods.ic2.nuclearcontrol.crossmod.RF.CrossBuildcraft;
+import shedar.mods.ic2.nuclearcontrol.crossmod.RF.CrossRF;
+import shedar.mods.ic2.nuclearcontrol.crossmod.appeng.CrossAppeng;
+import shedar.mods.ic2.nuclearcontrol.crossmod.bigreactors.CrossBigReactors;
+import shedar.mods.ic2.nuclearcontrol.crossmod.gregtech.GregtechRecipes;
+import shedar.mods.ic2.nuclearcontrol.crossmod.ic2.CrossIndustrialCraft2;
+import shedar.mods.ic2.nuclearcontrol.crossmod.ic2classic.CrossIndustrialCraft2Classic;
+import shedar.mods.ic2.nuclearcontrol.crossmod.opencomputers.CrossOpenComputers;
+import shedar.mods.ic2.nuclearcontrol.crossmod.railcraft.CrossRailcraft;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCard55Reactor;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardEnergyArrayLocation;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardEnergySensorLocation;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardLiquidArrayLocation;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardMultipleSensorLocation;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardReactorSensorLocation;
+import shedar.mods.ic2.nuclearcontrol.items.ItemCardText;
+import shedar.mods.ic2.nuclearcontrol.items.ItemKitEnergySensor;
+import shedar.mods.ic2.nuclearcontrol.items.ItemKitMultipleSensor;
+import shedar.mods.ic2.nuclearcontrol.items.ItemKitReactorSensor;
+import shedar.mods.ic2.nuclearcontrol.items.ItemNuclearControlLight;
+import shedar.mods.ic2.nuclearcontrol.items.ItemNuclearControlMain;
+import shedar.mods.ic2.nuclearcontrol.items.ItemTimeCard;
+import shedar.mods.ic2.nuclearcontrol.items.ItemToolDigitalThermometer;
+import shedar.mods.ic2.nuclearcontrol.items.ItemToolThermometer;
+import shedar.mods.ic2.nuclearcontrol.items.ItemUpgrade;
+import shedar.mods.ic2.nuclearcontrol.network.ChannelHandler;
+import shedar.mods.ic2.nuclearcontrol.panel.ScreenManager;
+import shedar.mods.ic2.nuclearcontrol.recipes.RecipesNew;
+import shedar.mods.ic2.nuclearcontrol.recipes.RecipesOld;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.SidedProxy;
@@ -14,31 +52,6 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
-import shedar.mods.ic2.nuclearcontrol.crossmod.ic2classic.CrossIndustrialCraft2Classic;
-
-import shedar.mods.ic2.nuclearcontrol.crossmod.bigreactors.CrossBigReactors;
-
-import java.io.File;
-import java.util.List;
-
-import net.minecraft.item.Item;
-import net.minecraftforge.common.MinecraftForge;
-import org.apache.logging.log4j.Logger;
-import shedar.mods.ic2.nuclearcontrol.blocks.BlockNuclearControlLight;
-import shedar.mods.ic2.nuclearcontrol.blocks.BlockNuclearControlMain;
-import shedar.mods.ic2.nuclearcontrol.crossmod.RF.CrossBuildcraft;
-import shedar.mods.ic2.nuclearcontrol.crossmod.RF.CrossRF;
-import shedar.mods.ic2.nuclearcontrol.crossmod.appeng.CrossAppeng;
-import shedar.mods.ic2.nuclearcontrol.crossmod.gregtech.GregtechRecipes;
-import shedar.mods.ic2.nuclearcontrol.crossmod.ic2.CrossIndustrialCraft2;
-import shedar.mods.ic2.nuclearcontrol.crossmod.opencomputers.CrossOpenComputers;
-import shedar.mods.ic2.nuclearcontrol.crossmod.railcraft.CrossRailcraft;
-import shedar.mods.ic2.nuclearcontrol.items.*;
-import shedar.mods.ic2.nuclearcontrol.network.ChannelHandler;
-import shedar.mods.ic2.nuclearcontrol.panel.ScreenManager;
-
-import shedar.mods.ic2.nuclearcontrol.recipes.RecipesNew;
-import shedar.mods.ic2.nuclearcontrol.recipes.RecipesOld;
 
 
 
@@ -191,7 +204,7 @@ public class IC2NuclearControl {
 		crossRailcraft = new CrossRailcraft();
 		crossRF = new CrossRF();
 		crossClassic = new CrossIndustrialCraft2Classic();
-
+		
 		if (recipes.equalsIgnoreCase("normal")) {
 			RecipesNew.addRecipes();
 		}
@@ -205,6 +218,7 @@ public class IC2NuclearControl {
 			GregtechRecipes.addRecipes();
 			logger.info("Hard... I mean, FUN recipes turned on! Have fun!");
 		}
+		
 		
 
 		/*

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/subblocks/RemoteThermo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/subblocks/RemoteThermo.java
@@ -28,6 +28,7 @@ public class RemoteThermo extends Subblock {
 			{ I_SIDE, I_SIDE, I_SIDE, I_SIDE, I_FACE, I_BACK } };
 
 	private IIcon[] icons = new IIcon[4];
+	
 
 	public RemoteThermo() {
 		super(DAMAGE, "tile.blockRemoteThermo");

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/subblocks/ThermalMonitor.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/blocks/subblocks/ThermalMonitor.java
@@ -37,6 +37,7 @@ public class ThermalMonitor extends Subblock {
 					I_FACE_GREEN, I_BACK } };
 
 	private IIcon[] icons = new IIcon[6];
+	
 
 	public ThermalMonitor() {
 		super(DAMAGE, "tile.blockThermalMonitor");

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/appeng/BlockNetworkLink.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/appeng/BlockNetworkLink.java
@@ -22,7 +22,7 @@ public class BlockNetworkLink extends BlockContainer {
     public BlockNetworkLink() {
         super(Material.iron);
         this.setBlockName("NetworkLink");
-        this.setBlockHardness(1.0F);
+        this.setHardness(1.0F);
         this.setCreativeTab(IC2NuclearControl.tabIC2NC);
     }
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemToolThermometer.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemToolThermometer.java
@@ -2,14 +2,12 @@ package shedar.mods.ic2.nuclearcontrol.items;
 
 import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorChamber;
-import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 import shedar.mods.ic2.nuclearcontrol.IC2NuclearControl;
-import shedar.mods.ic2.nuclearcontrol.tileentities.TileEntityThermo;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearHelper;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearNetworkHelper;
 import shedar.mods.ic2.nuclearcontrol.utils.TextureResolver;
@@ -39,20 +37,16 @@ public class ItemToolThermometer extends Item {
 			return false;
 		}
 		IReactor reactor = NuclearHelper.getReactorAt(world, x, y, z);
-        TileEntityReactorChamberElectric reactorChamber5x5 = null;
 		if (reactor == null) {
 			IReactorChamber chamber = NuclearHelper.getReactorChamberAt(world, x, y, z);
 			if (chamber != null) {
 				reactor = chamber.getReactor();
 			}
             if(reactor == null && chamber == null){
-                reactorChamber5x5 = (TileEntityReactorChamberElectric) ItemCard55Reactor.getReactor(world, x, y, z);
+            	reactor = ItemCard55Reactor.getReactor(world, x, y, z);
             }
 		}
-		if (reactor != null || TileEntityThermo.testThis(reactor, reactorChamber5x5)) {
-            if(reactorChamber5x5 != null){
-                reactor = reactorChamber5x5.getReactor();
-            }
+		if (reactor != null) {
 			messagePlayer(player, reactor);
 			damage(itemstack, 1, player);
 			return true;

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityRemoteThermo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityRemoteThermo.java
@@ -8,7 +8,6 @@ import ic2.api.item.IC2Items;
 import ic2.api.item.IElectricItem;
 import ic2.api.reactor.IReactor;
 import ic2.core.IC2;
-import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.Item;
@@ -31,6 +30,8 @@ import shedar.mods.ic2.nuclearcontrol.utils.BlockDamages;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearHelper;
 
 import java.util.List;
+
+import cpw.mods.fml.common.FMLLog;
 
 public class TileEntityRemoteThermo extends TileEntityThermo implements IEnergySink, ISlotItemFilter, IRotation, IInventory{
 	public static final int SLOT_CHARGER = 0;
@@ -94,7 +95,6 @@ public class TileEntityRemoteThermo extends TileEntityThermo implements IEnergyS
 		int fire;
 		if (energy >= IC2NuclearControl.instance.remoteThermalMonitorEnergyConsumption){
 			IReactor reactor = NuclearHelper.getReactorAt(worldObj, xCoord + deltaX, yCoord + deltaY, zCoord + deltaZ);
-            TileEntityReactorChamberElectric FiveSQReactor = null;
             //UUID cardType = null;
             if(reactor == null){
                 if (inventory[SLOT_CARD] != null){
@@ -104,14 +104,11 @@ public class TileEntityRemoteThermo extends TileEntityThermo implements IEnergyS
                     	int x = target.posX;
                     	int y = target.posY;
                     	int z = target.posZ;
-                    	FiveSQReactor = (TileEntityReactorChamberElectric) ItemCard55Reactor.getReactor(worldObj, x, y, z);
+                    	reactor = ItemCard55Reactor.getReactor(worldObj, x, y, z);
                     }
                 }
             }
-			if (reactor != null || TileEntityThermo.testThis(reactor, FiveSQReactor)){
-                if(FiveSQReactor != null){
-                    reactor = FiveSQReactor.getReactor();
-                }
+			if (reactor != null){
 				if (tickRate == -1){
 					tickRate = reactor.getTickRate() / 2;
 					if (tickRate == 0)

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityThermo.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/tileentities/TileEntityThermo.java
@@ -7,7 +7,10 @@ import ic2.api.reactor.IReactor;
 import ic2.api.reactor.IReactorChamber;
 import ic2.api.tile.IWrenchable;
 import ic2.core.IC2;
-import ic2.core.block.reactor.tileentity.TileEntityReactorChamberElectric;
+
+import java.util.List;
+import java.util.Vector;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
@@ -20,9 +23,6 @@ import shedar.mods.ic2.nuclearcontrol.blocks.subblocks.ThermalMonitor;
 import shedar.mods.ic2.nuclearcontrol.items.ItemCard55Reactor;
 import shedar.mods.ic2.nuclearcontrol.utils.BlockDamages;
 import shedar.mods.ic2.nuclearcontrol.utils.NuclearHelper;
-
-import java.util.List;
-import java.util.Vector;
 
 public class TileEntityThermo extends TileEntity implements INetworkDataProvider, INetworkUpdateListener,
 		INetworkClientTileEntityEventListener, IWrenchable, ITextureHelper {
@@ -205,7 +205,6 @@ public class TileEntityThermo extends TileEntity implements INetworkDataProvider
 		byte fire;
 		IReactorChamber chamber = NuclearHelper.getReactorChamberAroundCoord(worldObj, xCoord, yCoord, zCoord);
 		IReactor reactor = null;
-        TileEntityReactorChamberElectric NR = null;
 		if (chamber != null) {
 			reactor = chamber.getReactor();
 		}
@@ -216,13 +215,10 @@ public class TileEntityThermo extends TileEntity implements INetworkDataProvider
             //NCLog.fatal("CALLED");
             //NCLog.error(this.getFacing());
             decodeSides(xCoord, yCoord, zCoord);
-            NR = (TileEntityReactorChamberElectric) ItemCard55Reactor.getReactor(worldObj, Coords[0], Coords[1], Coords[2]);
+            reactor = ItemCard55Reactor.getReactor(worldObj, Coords[0], Coords[1], Coords[2]);
         }
 
-		if (reactor != null || testThis(reactor, NR)) {
-            if(NR != null){
-                reactor = NR.getReactor();
-            }
+		if (reactor != null) {
 			if (tickRate == -1) {
 				tickRate = reactor.getTickRate() / 2;
 				if (tickRate == 0) tickRate = 1;
@@ -253,14 +249,6 @@ public class TileEntityThermo extends TileEntity implements INetworkDataProvider
         Coords[0] = x + facing.offsetX;
         Coords[1] = y + facing.offsetY;
         Coords[2] = z + facing.offsetZ;
-    }
-    
-    public static boolean testThis(IReactor reactors, TileEntityReactorChamberElectric chamber){
-        if(reactors == null && chamber != null)
-            return true;
-        else
-            return false;
-
     }
 
 	@Override

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/NuclearHelper.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/utils/NuclearHelper.java
@@ -21,10 +21,13 @@ public class NuclearHelper {
 			return (IReactor) entity;
 		return null;
 	}
-
+	
+	
 	public static boolean isSteam(IReactor reactor) {
 		// no more steam reactors. Liquid container will be used for coolant
 		// liquids.
+		
+		//TODO Sooner or later Classic will have Steam Reactors
 		return false;// IC2NuclearControl.instance.crossBC.isTankContainer(reactor);
 	}
 


### PR DESCRIPTION
-Removed the IC2 Exp Source Requirement completly.
-Tested if the Nuclear Reactor 5x5 sensor Card (which was the only thing i was conserned which may not work) and it works fine. No trouble.
-ThermoMeter works also fine, ^^" I did not change that much. Only nessesary things

Note: This version will be compatible with IC2 Classic with the next update.
I needed to add 1 little thing to Classic which was the thing why some things from Nuclear Control did not load.