### PR TITLE
Fix for reactor timing

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/ic2/IC2ExpCross.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/crossmod/ic2/IC2ExpCross.java
@@ -5,6 +5,7 @@ import ic2.core.block.reactor.tileentity.TileEntityNuclearReactorElectric;
 import ic2.core.block.reactor.tileentity.TileEntityReactorAccessHatch;
 import ic2.core.block.reactor.tileentity.TileEntityReactorRedstonePort;
 import ic2.core.item.reactor.ItemReactorLithiumCell;
+import ic2.core.item.reactor.ItemReactorMOX;
 import ic2.core.item.reactor.ItemReactorUranium;
 import ic2.core.item.tool.ItemToolWrench;
 import net.minecraft.item.ItemStack;
@@ -20,18 +21,15 @@ public class IC2ExpCross extends IC2Cross{
 	
 	@Override
 	public int getNuclearCellTimeLeft(ItemStack par1) {
-		if(par1 == null)
+		if (par1 == null)
 		{
 			return 0;
 		}
-		if(par1.getItem() instanceof ItemReactorUranium)
+		if (par1.getItem() instanceof ItemReactorUranium || par1.getItem() instanceof ItemReactorLithiumCell || par1.getItem() instanceof ItemReactorMOX)
 		{
-			return 20000 - par1.getItemDamage();
+			return par1.getMaxDamage() - par1.getItemDamage();
 		}
-		else if(par1.getItem() instanceof ItemReactorLithiumCell)
-		{
-			return 10000 - par1.getItemDamage();
-		}
+
 		return 0;
 	}
 

--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemCardReactorSensorLocation.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemCardReactorSensorLocation.java
@@ -58,16 +58,26 @@ public class ItemCardReactorSensorLocation extends ItemCardBase implements
 
 			IInventory inventory = (IInventory) reactor;
 			int slotCount = inventory.getSizeInventory();
-			int timeLeft = 0;
+			int dmgLeft = 0;
 			for (int i = 0; i < slotCount; i++) {
 				ItemStack rStack = inventory.getStackInSlot(i);
 				if (rStack != null) {
-					timeLeft = Math.max(timeLeft,
+					dmgLeft = Math.max(dmgLeft,
 							NuclearHelper.getNuclearCellTimeLeft(rStack));
 				}
 			}
+
+
+			int timeLeft = 0;
+
 			//Classic has a Higher Tick rate for Steam generation but damage tick rate is still the same...
-			card.setInt("timeLeft", timeLeft * (isSteam ? 20 : reactor.getTickRate()) / 20);
+			if (isSteam) {
+				timeLeft = dmgLeft;
+			} else {
+				timeLeft = dmgLeft * reactor.getTickRate() / 10;
+			}
+
+			card.setInt("timeLeft", timeLeft);
 			return CardState.OK;
 		} else {
 			return CardState.NO_TARGET;
@@ -90,15 +100,16 @@ public class ItemCardReactorSensorLocation extends ItemCardBase implements
 
 			IInventory inventory = (IInventory) reactor;
 			int slotCount = inventory.getSizeInventory();
-			int timeLeft = 0;
+			int dmgLeft = 0;
 			for (int i = 0; i < slotCount; i++) {
 				ItemStack rStack = inventory.getStackInSlot(i);
 				if (rStack != null) {
-					timeLeft = Math.max(timeLeft,
+					dmgLeft = Math.max(dmgLeft,
 							NuclearHelper.getNuclearCellTimeLeft(rStack));
 				}
 			}
-			card.setInt("timeLeft", timeLeft * reactor.getTickRate() / 20);
+
+			card.setInt("timeLeft", dmgLeft * reactor.getTickRate() / 10);
 			return CardState.OK;
 		} else {
 			return CardState.NO_TARGET;


### PR DESCRIPTION
- Using function ``getMaxDamage()`` for fuel rods damage now, makes more sense than hardcoding the values
- ``NuclearHelper.getNuclearCellTimeLeft(rStack))`` is returning the durability of the fuel rods, not the time that they have left
- Since they have a durability of 10000, but last for 20000 seconds, the old calculation had to be multiplied by 2
- Also, I changed the name of the variable ``timeLeft`` to ``dmgLeft`` to avoid confusion.