### PR TITLE
Portable information panel duplication fix

### DIFF
--- a/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemRemoteMonitor.java
+++ b/src/main/java/shedar/mods/ic2/nuclearcontrol/items/ItemRemoteMonitor.java
@@ -19,13 +19,13 @@ public class ItemRemoteMonitor extends Item{
 
     public ItemRemoteMonitor(){
         this.setCreativeTab(IC2NuclearControl.tabIC2NC);
-
+        this.setMaxStackSize(1);
     }
 
     @Override
     public ItemStack onItemRightClick(ItemStack stack, World world, EntityPlayer player)
     {
-        if(!player.isSneaking()) {
+        if(!player.isSneaking() && !world.isRemote && stack.stackSize == 1) {
             player.openGui(IC2NuclearControl.instance, GuiRemoteMonitor.REMOTEMONITOR_GUI, world, 0, 0, 0);
         }
         return stack;


### PR DESCRIPTION
The items with the inventory not be stackable. It causes duplication. Also you need block number keys in inventory. They can used for replace item in hand.