### PR TITLE
fix version number in mcmod.info fix #185

### DIFF
--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -3,7 +3,7 @@
 	"modid": "IC2NuclearControl",
 	"name": "Nuclear Control 2",
 	"description": "Nuclear Control, an Industrial Craft 2 addon that allows you to build efficient monitoring and notification system for your nuclear reactor. Also you can use Howler Alarm and Industrial Alarm in any case when you want industrial-style notification/alarming system.",
-	"version": "@VERSION@",
+	"version": "${version}",
 	"mcversion": "1.7.10",
 	"logoFile": "",
 	"url": "http://forum.industrial-craft.net/index.php?page=Thread&threadID=5915",


### PR DESCRIPTION
uses gradle's versioning instead of the forge plugin. this gets its version from the project version set by version in build.gradle.

This should fix the issue fix #185